### PR TITLE
Allow data to be persisted on disk using the -v flag on runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ docker run -it --rm -e SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN --name gamify-bot-replic
 
 **Warning**: Keep your `SLACK_BOT_TOKEN` secret, do not pass the value directly as argument to the command.
 
+You can persist the data inside the docker container on your host system by doing the following actions:
+1. Create a data directory on a suitable volume on your host system, e.g. `/my/own/datadir`
+2. Start your gamify-bot container like this:
+
+```bash
+docker run -it --rm -e SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN -v /my/own/datadir:/usr/src/app/data --name gamify-bot-replica gamify-bot
+```
+
+The -v `/my/own/datadir:/usr/src/app/data` part of the command mounts the /my/own/datadir directory from the underlying host system as /usr/src/app/data inside the container, where gamify-bot by default will write its data files.
+
 ## License
 
 GamifyBot is licensed under the liberal [MIT License](./LICENSE).

--- a/bot-config.yml
+++ b/bot-config.yml
@@ -2,7 +2,7 @@
 
 # SQLite 3 database file to persist the game data
 db:
- file_name: "gamifybot.db"
+ file_name: "db/gamifybot.db"
 
 # Declare a list of Slack IDs here to indicate users that can perform admin commands.
 admin:

--- a/bot-config.yml
+++ b/bot-config.yml
@@ -2,7 +2,7 @@
 
 # SQLite 3 database file to persist the game data
 db:
- file_name: "db/gamifybot.db"
+ file_name: "data/gamifybot.db"
 
 # Declare a list of Slack IDs here to indicate users that can perform admin commands.
 admin:


### PR DESCRIPTION
now it is possible to add for example -v /d/gamify-bot/db:/usr/src/app/db in order to persist the data on disk